### PR TITLE
Removed replication entry

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -21,6 +21,3 @@ storage:
     dbPath: "/var/lib/mongo"
     journal:
         enabled: true
-
-replication:
-    replSetName: "{{ mongodb_replica_set_name }}"


### PR DESCRIPTION
For TLO SA the Mongodb service throws an error related to 'master/slave' not being present, this was because it was expecting a replica set due to the original configuration file having a replica set entry.